### PR TITLE
楽曲選択で直前に遊んでいた楽曲・難易度が選択されるようにした

### DIFF
--- a/Assets/MusicSelection/Scripts/MusicSelectionManager.cs
+++ b/Assets/MusicSelection/Scripts/MusicSelectionManager.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 using Rhythm;
+using Transition;
 
 namespace MusicSelection
 {
@@ -21,7 +22,7 @@ namespace MusicSelection
 
             TrackDict = _trackData.TrackDictionary.Where(x => x.Value.HasBeatmap)
                 .ToDictionary(x => x.Key, x => x.Value);
-            _difficultySelection = new DifficultySelection(_firstSelectedDifficulty);
+            _difficultySelection = new DifficultySelection(SceneTransitionManager.CurrentDifficulty);
         }
 
         protected override void Start()

--- a/Assets/MusicSelection/Scripts/MusicSelectionManagerBase.cs
+++ b/Assets/MusicSelection/Scripts/MusicSelectionManagerBase.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using Gallery;
+using Transition;
 
 namespace MusicSelection
 {
@@ -34,7 +35,6 @@ namespace MusicSelection
 
         private void GenerateUIElements()
         {
-            var isFirst = true;
             var posY = 0f;
             var height = _musicUIElementPrefab.GetComponent<RectTransform>().rect.height;
 
@@ -51,9 +51,14 @@ namespace MusicSelection
 
                 posY -= height;
 
-                if (!isFirst) continue;
-                _eventSystem.firstSelectedGameObject = element.gameObject;
-                isFirst = false;
+                // OPTIMIZE:
+                // Enum.ToString()の実装速度が比較的遅いためボトルネックになっている可能性あり．
+                // 現状気になるほどの遅延は見られないのでこの実装でいく．
+                if (_eventSystem.firstSelectedGameObject == null || 
+                    trackInformation.Id == SceneTransitionManager.CurrentRhythmId.ToString())
+                {
+                    _eventSystem.firstSelectedGameObject = element.gameObject;
+                }
             }
         }
 


### PR DESCRIPTION
- close #218 
- 「直前の曲」情報はギャラリーとも共通です．つまり，ギャラリーでも直前に遊んだ曲がデフォで選択されます．