### PR TITLE
Feature/display notesdesigner and achievement

### DIFF
--- a/Assets/MusicSelection/Scripts/MusicSelectionManager.cs
+++ b/Assets/MusicSelection/Scripts/MusicSelectionManager.cs
@@ -29,7 +29,7 @@ namespace MusicSelection
         {
             base.Start();
 
-            UpdateDifficultyRelatedUI();
+            _difficultyDisplay.Set();
         }
 
         public void OnNavigateHorizontal(InputValue inputValue)

--- a/Assets/MusicSelection/Scripts/MusicSelectionThumbnail.cs
+++ b/Assets/MusicSelection/Scripts/MusicSelectionThumbnail.cs
@@ -7,30 +7,48 @@ namespace MusicSelection
 {
     public class MusicSelectionThumbnail : ThumbnailBase
     {
-        private TrackInformation _trackCache;
-        
+        private TrackInformation _track;
+        private NotesInformation[] _notes;
+
+        [SerializeField] private TextMeshProUGUI _notesDesignerText;
+
         [SerializeField] private TextMeshProUGUI _bestScoreText;
         [SerializeField] private TextMeshProUGUI _maxComboText;
 
+        [SerializeField] private TextMeshProUGUI _allPerfectText;
+        [SerializeField] private TextMeshProUGUI _fullComboText;
+
         [SerializeField] private RecordList _recordList;
+        [SerializeField] private BeatmapData _beatmapData;
 
         public override void Set(TrackInformation track)
         {
-            _trackCache = track;
-            
+            _track = track;
             _image.sprite = track.Thumbnail;
-
             _titleText.text = track.Title;
             _composerText.text = track.Composer;
+
+            _notes = _beatmapData.BeatmapDictionary[track.Id].Notes;
 
             Set(DifficultySelection.Current);
         }
 
         public void Set(Difficulty difficulty)
         {
-            var record = _recordList[_trackCache.Id][(int)difficulty];
+            var record = _recordList[_track.Id][(int)difficulty];
             _bestScoreText.text = $"{record.Score.ToString()} pt";
             _maxComboText.text = $"{record.MaxCombo.ToString()} combo";
+
+            _allPerfectText.gameObject.SetActive(record.Achievement switch
+            {
+                Achievement.AllPerfect => true, _ => false
+            });
+            _fullComboText.gameObject.SetActive(record.Achievement switch
+            {
+                Achievement.FullCombo => true, _ => false
+            });
+
+            _notesDesignerText.text = _notes[(int)difficulty].NotesDesigner;
         }
     }
 }

--- a/Assets/Rhythm/Beatmaps/BeatmapData.asset
+++ b/Assets/Rhythm/Beatmaps/BeatmapData.asset
@@ -39,13 +39,13 @@ MonoBehaviour:
     _enemySprite: {fileID: 21300000, guid: 7af8cc4661d62cf4ba532915b829d782, type: 3}
     _notes:
     - _level: 0
-      _notesDesigner: 
+      _notesDesigner: "\u3075\u3043\u30FC\u306D"
       _file: {fileID: 4900000, guid: b5378326c8f48214b99c44109da81366, type: 3}
     - _level: 0
-      _notesDesigner: 
+      _notesDesigner: "\u3075\u3043\u30FC\u306D"
       _file: {fileID: 4900000, guid: f6fe2ba841d4add428d82c0b296b4a51, type: 3}
     - _level: 0
-      _notesDesigner: 
+      _notesDesigner: "\u3075\u3043\u30FC\u306D"
       _file: {fileID: 4900000, guid: 25d2cd560cc8bc44095ec238d8b6a3a8, type: 3}
   - _id: Chapter2_2
     _title: "\u8A66\u594F\u301C\u9B54\u7269\u9054\u306E\u5C0F\u54C1\u301C"
@@ -54,7 +54,16 @@ MonoBehaviour:
     _composer: "\u7532\u6590\u5927\u6210"
     _backgroundSprite: {fileID: 0}
     _enemySprite: {fileID: 0}
-    _notes: []
+    _notes:
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
   - _id: Chapter2_4
     _title: "\u8972\u6F14\u301C\u4E3B\u306E\u72EC\u594F\u301C"
     _sound: {fileID: 0}
@@ -62,7 +71,16 @@ MonoBehaviour:
     _composer: "\u3068\u308A\u3068\u308A"
     _backgroundSprite: {fileID: 0}
     _enemySprite: {fileID: 0}
-    _notes: []
+    _notes:
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
   - _id: Chapter1
     _title: "\u30BD\u30CC\u30B9\u30EB\u30D7\u30B9\u8857"
     _sound: {fileID: 8300000, guid: ecdf4e8d3125a8b4e98f3c2c50bf6ce5, type: 3}
@@ -72,13 +90,13 @@ MonoBehaviour:
     _enemySprite: {fileID: 0}
     _notes:
     - _level: 0
-      _notesDesigner: 
+      _notesDesigner: "\u3075\u3043\u30FC\u306D"
       _file: {fileID: 4900000, guid: 98401f284ac61c64f820025d81b392d4, type: 3}
     - _level: 0
-      _notesDesigner: 
+      _notesDesigner: "\u3075\u3043\u30FC\u306D"
       _file: {fileID: 4900000, guid: e8b01502d937bf649ab0bd5c5f75939b, type: 3}
     - _level: 0
-      _notesDesigner: 
+      _notesDesigner: "\u3075\u3043\u30FC\u306D"
       _file: {fileID: 4900000, guid: be73c18d3fc7a53459ecc7b05b13f72f, type: 3}
   - _id: Chapter2
     _title: "\u30EA\u30FC\u30C8\u306E\u68EE"
@@ -87,4 +105,13 @@ MonoBehaviour:
     _composer: "\u7AF9\u4E0B\u5B9F\u7A42"
     _backgroundSprite: {fileID: 0}
     _enemySprite: {fileID: 0}
-    _notes: []
+    _notes:
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}
+    - _level: 0
+      _notesDesigner: 
+      _file: {fileID: 0}

--- a/Assets/Scenes/MusicSelection.unity
+++ b/Assets/Scenes/MusicSelection.unity
@@ -217,7 +217,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Composer's name
+  m_text: Composer
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
   m_sharedMaterial: {fileID: -1691510107456059026, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
@@ -863,6 +863,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 810395610}
   m_CullTransparentMesh: 1
+--- !u!1 &889681950
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889681951}
+  m_Layer: 5
+  m_Name: Achievement
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &889681951
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889681950}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1365804505}
+  - {fileID: 2030625858}
+  m_Father: {fileID: 1671466894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 650, y: -380}
+  m_SizeDelta: {x: -700, y: -430}
+  m_Pivot: {x: 0, y: 1}
 --- !u!1 &983387255
 GameObject:
   m_ObjectHideFlags: 0
@@ -1530,6 +1567,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1295608594}
   m_CullTransparentMesh: 1
+--- !u!1 &1365804504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1365804505}
+  - component: {fileID: 1365804507}
+  - component: {fileID: 1365804506}
+  m_Layer: 5
+  m_Name: AllPerfectText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1365804505
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365804504}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 889681951}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -80}
+  m_SizeDelta: {x: 0, y: 60}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1365804506
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365804504}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: ALL PERFECT
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
+  m_sharedMaterial: {fileID: -1691510107456059026, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 1
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 0.2, b: 0, a: 1}
+    topRight: {r: 1, g: 0.7, b: 0, a: 1}
+    bottomLeft: {r: 0, g: 1, b: 0.3, a: 1}
+    bottomRight: {r: 0, g: 0.2, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 56
+  m_fontSizeBase: 56
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1365804507
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1365804504}
+  m_CullTransparentMesh: 1
 --- !u!1 &1411164420
 GameObject:
   m_ObjectHideFlags: 0
@@ -2065,8 +2236,10 @@ RectTransform:
   - {fileID: 1866744704}
   - {fileID: 675124262}
   - {fileID: 275685218}
+  - {fileID: 1688605067}
   - {fileID: 1281821947}
   - {fileID: 206696136}
+  - {fileID: 889681951}
   m_Father: {fileID: 1443423169}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
@@ -2127,9 +2300,147 @@ MonoBehaviour:
   _image: {fileID: 1799237809}
   _titleText: {fileID: 675124263}
   _composerText: {fileID: 275685219}
+  _notesDesignerText: {fileID: 1688605068}
   _bestScoreText: {fileID: 1295608596}
   _maxComboText: {fileID: 1059607589}
+  _allPerfectText: {fileID: 1365804506}
+  _fullComboText: {fileID: 2030625859}
   _recordList: {fileID: 11400000, guid: e00e481882f388c419b380ce48e3d8b8, type: 2}
+  _beatmapData: {fileID: 11400000, guid: 18962a94c1f47984292377afa62aae5b, type: 2}
+--- !u!1 &1688605066
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1688605067}
+  - component: {fileID: 1688605069}
+  - component: {fileID: 1688605068}
+  m_Layer: 5
+  m_Name: NotesDesignerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1688605067
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688605066}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1671466894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 250, y: 50}
+  m_SizeDelta: {x: -600, y: 48}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &1688605068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688605066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: NotesDesigner
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
+  m_sharedMaterial: {fileID: -1691510107456059026, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281940281
+  m_fontColor: {r: 0.22352941, g: 0.22352941, b: 0.22352941, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1688605069
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1688605066}
+  m_CullTransparentMesh: 1
 --- !u!1 &1691401063
 GameObject:
   m_ObjectHideFlags: 0
@@ -2442,6 +2753,140 @@ RectTransform:
   m_AnchoredPosition: {x: -225, y: 91.5}
   m_SizeDelta: {x: -550, y: -283}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2030625857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2030625858}
+  - component: {fileID: 2030625860}
+  - component: {fileID: 2030625859}
+  m_Layer: 5
+  m_Name: FullComboText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2030625858
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030625857}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 889681951}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -80}
+  m_SizeDelta: {x: 0, y: 60}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &2030625859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030625857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: FULL COMBO
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
+  m_sharedMaterial: {fileID: -1691510107456059026, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278245887
+  m_fontColor: {r: 1, g: 0.8509804, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 0
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 0.2, b: 0, a: 1}
+    topRight: {r: 1, g: 0.2, b: 0, a: 1}
+    bottomLeft: {r: 1, g: 0.2, b: 0, a: 1}
+    bottomRight: {r: 1, g: 0.2, b: 0, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 56
+  m_fontSizeBase: 56
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2030625860
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030625857}
+  m_CullTransparentMesh: 1
 --- !u!1 &2054128551
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- close #224 
- ロジックができたので投げます．見た目はまた後で整えればいいと思います．
- アチーブメント（フルコン・AP）のフォントは音ゲーパートのリザルトからお借りしました．
  - 見づらいかも．黒っぽい背景を差し込むか，フォントカラーを変更したほうがいい．
- 作曲と譜面制作，どっちがどっちかわからない問題
  - 作曲アイコン🎼と譜面制作アイコン⚔️🛡️を作って置いとくとか？
  - 譜面制作アイコンはノーツ素材で作れそう
![image](https://github.com/user-attachments/assets/fcbac9c4-05e3-4c54-b443-85c18c31d7cd)
![image](https://github.com/user-attachments/assets/3db26021-104c-4e29-bf82-be15a1651f3d)
（APの写真はセーブデータ書き換えによるものなのでスコアが1000000ptになっていません）