### PR TITLE
ホールド帯の描画順を修正した

### DIFF
--- a/Assets/Rhythm/Scripts/Logics/Managers/NoteCreator.cs
+++ b/Assets/Rhythm/Scripts/Logics/Managers/NoteCreator.cs
@@ -36,6 +36,7 @@ namespace Rhythm
 
         private readonly List<Note> _notes;
         private readonly List<RhythmGameObject> _rhythmGameObjects;
+        private readonly Stack<double> _bandEndTimes;
         private int _noteCount;
 
 
@@ -58,6 +59,8 @@ namespace Rhythm
 
             _notes = new List<Note>();
             _rhythmGameObjects = new List<RhythmGameObject>();
+            _bandEndTimes = new Stack<double>();
+            _bandEndTimes.Push(double.PositiveInfinity);
             _noteCount = 0;
         }
 
@@ -128,6 +131,21 @@ namespace Rhythm
                                 var deltaTime = 30 / note.Bpm;
                                 var time = note.JustTime + deltaTime;
                                 var endTime = note.JustTime + note.Length;
+                                int order;
+
+                                while (true)
+                                {
+                                    if (time < _bandEndTimes.Peek())
+                                    {
+                                        order = _bandEndTimes.Count - 1;
+                                        _bandEndTimes.Push(endTime);
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        _bandEndTimes.Pop();
+                                    }
+                                }
 
                                 while (time < endTime && !Mathf.Approximately((float)time, (float)endTime))
                                 {
@@ -143,7 +161,7 @@ namespace Rhythm
 
                                 var bandLength = lastPosition.y - firstPosition.y;
                                 var rect = (_survivalRect.UpperLeft, _survivalRect.LowerRight - new Vector2(0f, bandLength));
-                                obj.Create(firstPosition, new Vector3(0f, -note.Speed), rect, note.Lane, bandLength, note.JustTime, endTime, disposable);
+                                obj.Create(firstPosition, new Vector3(0f, -note.Speed), rect, note.Lane, bandLength, note.JustTime, endTime, order, disposable);
                                 if (isNew) _rhythmGameObjects.Add(obj);
                             }
                         }

--- a/Assets/Rhythm/Scripts/MonoBehaviours/Others/HoldBand.cs
+++ b/Assets/Rhythm/Scripts/MonoBehaviours/Others/HoldBand.cs
@@ -49,7 +49,7 @@ namespace Rhythm
             _releasedColor.a = 0.5f;
         }
 
-        public void Create(Vector3 position, Vector3 velocity, (Vector2 UpperLeft, Vector2 LowerRight) survivalRect, int lane, float length, double beginTime, double endTime, IDisposable disposable)
+        public void Create(Vector3 position, Vector3 velocity, (Vector2 UpperLeft, Vector2 LowerRight) survivalRect, int lane, float length, double beginTime, double endTime, int order, IDisposable disposable)
         {
             _defaultScale = new Vector3 (transform.localScale.x, length, transform.localScale.z);
             _currentScale = _defaultScale;
@@ -58,6 +58,7 @@ namespace Rhythm
             _endTime = endTime;
             _holdPosition = new Vector3(position.x, _judgeLineY, position.z);
             _renderer.color = _defaultColor;
+            _renderer.sortingOrder = order;
 
             Create(position, velocity, survivalRect, lane, x => 
             {

--- a/Assets/Scenes/Rhythm.unity
+++ b/Assets/Scenes/Rhythm.unity
@@ -48611,7 +48611,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 0,000,000
+  m_text: 0
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}
   m_sharedMaterial: {fileID: -1691510107456059026, guid: 24f5290adcd4088449581d2e50e0d9a9, type: 2}


### PR DESCRIPTION
ロングノーツ帯の描画順について，開始時刻が遅いものほど前に描画されるようにした．

変更前
![image](https://github.com/user-attachments/assets/bb4cc193-024d-4550-98a4-2e1dc0725043)

変更後
![image](https://github.com/user-attachments/assets/f1d4f181-418d-4b4a-a389-02be026535fa)