### PR TITLE
Creditシーンに遷移するときにSE音量がデフォルトに戻るように修正

### DIFF
--- a/Assets/Transition/Scripts/SceneTransitionManager.cs
+++ b/Assets/Transition/Scripts/SceneTransitionManager.cs
@@ -152,6 +152,8 @@ namespace Transition
 
 		public static void TransitionToCredit()
 		{
+			_settingsManager.SetDefaultSeVolume();
+
 			TransitionToScene(SceneName.Credit);
 		}
 


### PR DESCRIPTION
- Novel -> MapでSeVolumeがノベル用からその他用に戻るようになってる
- Novel -> Credit -> Titleで戻らないようになってたので対応