### PR TITLE
Chapter1-2初回プレイ時の進行不能バグを修正

### DIFF
--- a/Assets/Rhythm/Scripts/MonoBehaviours/Managers/EventManager.cs
+++ b/Assets/Rhythm/Scripts/MonoBehaviours/Managers/EventManager.cs
@@ -67,7 +67,7 @@ namespace Rhythm
 				switch (_tutorialId)
 				{
 					case TutorialId.None:
-						if (SceneTransitionManager.RecentSceneName == SceneName.Map)
+						if (SceneTransitionManager.RecentSceneName == SceneName.Map || SceneTransitionManager.RecentSceneName == SceneName.Rhythm)
 						{
 							SceneTransitionManager.TransitionToMap(_battleMode.IsWin);
 
@@ -147,7 +147,7 @@ namespace Rhythm
 
 				Time.timeScale = 1;
 
-				if (SceneTransitionManager.RecentSceneName == SceneName.Map)
+				if (SceneTransitionManager.RecentSceneName == SceneName.Map || SceneTransitionManager.RecentSceneName == SceneName.Rhythm)
 				{
 					SceneTransitionManager.TransitionToMap();
 				}


### PR DESCRIPTION
Rhythmから戻る先を「直前のシーンがMapだったか」で判断していたため、チュートリアルが挟まる初回1-2では正常に処理が行われていなかった